### PR TITLE
有線LAN接続したMac上のシミュレーターで常にnetworkErrorになってしまう問題を解決

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,24 @@ do {
 
 ## Installation
 Swift Package Managerを使ってインストールすることができます。Xcodeの `File > Add Packages...` から `https://github.com/pixiv/ios-tutorial-api-mock` を入力して利用できます
+
+## Tips
+有線LANを接続したMac上のiOS Simulatorで開発をしている場合、 `IllustError.networkError` が発生してAPIリクエストに失敗します。
+次のコードに書き換えることで、シミュレーター上で動かすことが可能になります。
+
+```swift
+import IllustAPIMock
+
+let api = IllustAPIMock()
+api.networkMonitor = NetworkMonitorImpl(interfaceType: .wiredEthernet) // この行を追加
+
+do {
+    let rankingIllusts = try await api.getRanking()
+    let recommendedIllusts = try await api.getRecommended()
+    _ = try await api.postIsFavorited(illustID: ..., isFavorited: true)
+} catch {
+    ...
+}
+```
+
+ただし、この変更を行ったコードを実機で動かした場合は、iPhone/iPadが有線LANに接続していない場合に `IllustError.networkError` が発生する点に注意して下さい。

--- a/Sources/IllustAPIMock/IllustAPIMock.swift
+++ b/Sources/IllustAPIMock/IllustAPIMock.swift
@@ -2,7 +2,7 @@ import CoreData
 import Foundation
 
 public class IllustAPIMock {
-    var networkMonitor: NetworkMonitor = NetworkMonitorImpl()
+    public var networkMonitor: NetworkMonitor = NetworkMonitorImpl()
 
     private static let databaseName = "Illusts"
     private static let entityName = "IllustEntity"

--- a/Sources/IllustAPIMock/IllustAPIMock.swift
+++ b/Sources/IllustAPIMock/IllustAPIMock.swift
@@ -2,7 +2,11 @@ import CoreData
 import Foundation
 
 public class IllustAPIMock {
-    public var networkMonitor: NetworkMonitor = NetworkMonitorImpl()
+    public var networkMonitor: NetworkMonitor = NetworkMonitorImpl() {
+        didSet {
+            networkMonitor.start()
+        }
+    }
 
     private static let databaseName = "Illusts"
     private static let entityName = "IllustEntity"
@@ -16,8 +20,6 @@ public class IllustAPIMock {
         container.loadPersistentStores { _, _ in }
 
         setup()
-
-        networkMonitor.start()
     }
 
     public func getRanking(offset: Int = 0) async throws -> [Illust] {

--- a/Sources/IllustAPIMock/NetworkMonitor.swift
+++ b/Sources/IllustAPIMock/NetworkMonitor.swift
@@ -6,11 +6,14 @@ public protocol NetworkMonitor {
 }
 
 public class NetworkMonitorImpl: NetworkMonitor {
-    private let monitor = NWPathMonitor(requiredInterfaceType: .wifi)
-    private let queue = DispatchQueue.global(qos: .background)
+    private let monitor: NWPathMonitor
+
+    public init(interfaceType: NWInterface.InterfaceType = .wifi) {
+        monitor = NWPathMonitor(requiredInterfaceType: interfaceType)
+    }
 
     public func start() {
-        monitor.start(queue: queue)
+        monitor.start(queue: .global(qos: .background))
     }
 
     public func isConnected() -> Bool {

--- a/Sources/IllustAPIMock/NetworkMonitor.swift
+++ b/Sources/IllustAPIMock/NetworkMonitor.swift
@@ -12,6 +12,10 @@ public class NetworkMonitorImpl: NetworkMonitor {
         monitor = NWPathMonitor(requiredInterfaceType: interfaceType)
     }
 
+    deinit {
+        monitor.cancel()
+    }
+
     public func start() {
         monitor.start(queue: .global(qos: .background))
     }


### PR DESCRIPTION
## 問題
NetworkMonitorImpl 内では `NWPathMonitor(requiredInterfaceType: .wifi)` といった記述で `.wifi` をモニタリング対象に指定している。しかしシミュレーターはMacの状態を引き継ぐため、有線LANに接続されたMac上のシミュレーターでは有線LANに接続がされているものとして動く。

このため `NWPathMonitor(requiredInterfaceType: .wifi)` が常に `unsatisfied` 状態となり、APIMockでnetworkErrorとして扱われてしまう。

この問題は有線LANもWifiも両方接続しているMac上でも発生する。

## 本P-Rでの解決方法
- `NetworkMonitorImpl` に `init`を追加し、外から監視するInferfaceを渡せるようにした
- `IllustAPIMock.networkMonitor` のアクセス修飾子を `internal` から `public` に変更しライブラリ利用者が変更可能とした
- `IllustAPIMock.init`内部で行われていた `NetworkMonitor` の起動処理の場所を移動させた
- `README.md` に有線LANを利用している場合のサンプルコードを追記した